### PR TITLE
Fix timer callback being invoked immediately in defeat expiry

### DIFF
--- a/AbsoluteDefeat/Mods/AbsoluteDefeat/ScriptExtender/Lua/Server/AD.lua
+++ b/AbsoluteDefeat/Mods/AbsoluteDefeat/ScriptExtender/Lua/Server/AD.lua
@@ -437,7 +437,9 @@ function StartDefeatScenario(combatguid)
     Utils.Debug("EXPIRING DEFEAT")
     for i, victim in ipairs(defeatedNotImprisonedParty) do
         Utils.Debug("Expiring defeat for char: " .. victim)
-        Ext.Timer.WaitFor(100, AD.ExpireDefeatStateInTime(victim, 30))
+        Ext.Timer.WaitFor(100, function()
+            AD.ExpireDefeatStateInTime(victim, 30)
+        end)
     end
 end
 


### PR DESCRIPTION
This fixes a timer callback issue where Ext.Timer.WaitFor is passed the result of AD.ExpireDefeatStateInTime(victim, 30) instead of a function.

Current behavior:
- AD.ExpireDefeatStateInTime is executed immediately
- its return value is passed to WaitFor
- if the return value is nil, the timer later throws "attempt to call a nil value"

Fix:
- wrap the call in an anonymous function so it executes when the timer fires